### PR TITLE
Add Angular welcome page

### DIFF
--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 
 export const routes: Routes = [
-  { path: '', title: 'Configure rgbw-ctrl', loadComponent: () => import('./rgbw-ctrl/rgbw-ctrl.component').then(m => m.RgbwCtrlComponent) },
+  { path: '', title: 'Welcome', loadComponent: () => import('./welcome/welcome.component').then(m => m.WelcomeComponent) },
+  { path: 'configure', title: 'Configure rgbw-ctrl', loadComponent: () => import('./rgbw-ctrl/rgbw-ctrl.component').then(m => m.RgbwCtrlComponent) },
 ];

--- a/app/src/app/welcome/welcome.component.html
+++ b/app/src/app/welcome/welcome.component.html
@@ -1,0 +1,12 @@
+<mat-card>
+  <h1>Welcome to rgbw-ctrl</h1>
+  <p>
+    rgbw-ctrl is an ESP32 RGBW LED controller with web-based configuration and Alexa support.
+    The firmware exposes Bluetooth Low Energy for initial setup, Wi‑Fi connectivity,
+    a REST API, real‑time WebSocket control and OTA updates.
+  </p>
+  <p>
+    When you are ready, continue to the configuration page to connect and customize your device.
+  </p>
+  <a mat-raised-button color="primary" routerLink="/configure">Configure device</a>
+</mat-card>

--- a/app/src/app/welcome/welcome.component.scss
+++ b/app/src/app/welcome/welcome.component.scss
@@ -1,0 +1,15 @@
+:host {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+mat-card {
+  max-width: 600px;
+  padding: 1.5rem;
+  text-align: center;
+}
+
+mat-card h1 {
+  margin-top: 0;
+}

--- a/app/src/app/welcome/welcome.component.ts
+++ b/app/src/app/welcome/welcome.component.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatButtonModule} from '@angular/material/button';
+import {MatCardModule} from '@angular/material/card';
+import {RouterLink} from '@angular/router';
+
+@Component({
+  selector: 'app-welcome',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatCardModule, RouterLink],
+  templateUrl: './welcome.component.html',
+  styleUrl: './welcome.component.scss'
+})
+export class WelcomeComponent {}


### PR DESCRIPTION
## Summary
- add standalone WelcomeComponent
- route '/' to the welcome page
- move existing configuration UI to `/configure`

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861435fb6f4832facb35d6efaae5637