### PR TITLE
Add docs for ESP-NOW remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * **WebSocket:** Low-latency bidirectional communication
 * **OTA Updates:** Update firmware and UI over HTTP
 * **Rotary Encoder Support:** Optional hardware input for manual brightness control and BLE activation
+* **ESP-NOW Remote Control:** Optional secondary firmware for wireless control
 
 ---
 
@@ -50,10 +51,11 @@ Functionality is built-in and automatically enabled if the encoder is connected.
 
 | Path          | Description                     |
 | ------------- | ------------------------------- |
-| `/firmware`   | PlatformIO-based ESP32 firmware |
+| `/firmware`   | PlatformIO-based ESP32 firmware (controller & remote) |
 | `/filesystem` | Web-based device UI             |
 | `/app`        | Angular configuration app       |
 | `/doc`        | Additional documentation        |
+| `/doc/REMOTE.md` | ESP-NOW remote firmware docs  |
 
 ---
 
@@ -75,11 +77,24 @@ Functionality is built-in and automatically enabled if the encoder is connected.
    cd ../firmware
    pio run -t upload
    ```
-4. Upload web UI files:
+4. (Optional) Build and upload the remote firmware:
 
    ```bash
-   pio run -t uploadfs
+   pio run -e remote -t upload
    ```
+5. Upload web UI files:
+
+   ```bash
+pio run -t uploadfs
+```
+
+---
+
+## 📡 Remote Firmware
+
+An additional PlatformIO environment builds `remote.cpp`, providing a wireless
+ESP-NOW remote for the controller. The remote shares the same BLE setup and OTA
+update flow as the main firmware. See [doc/REMOTE.md](doc/REMOTE.md) for details.
 
 ---
 
@@ -255,6 +270,8 @@ See full details in the [OtaHandler documentation](doc/OTA.md).
 cd filesystem && npm install && npm run build
 cd ../firmware && pio run -t upload
 pio run -t uploadfs  # or use curl + /update endpoint
+# to flash the optional ESP-NOW remote use:
+# pio run -e remote -t upload
 ```
 
 ---
@@ -268,4 +285,4 @@ More info:
 * [firmware/README.md](firmware/README.md)
 * [filesystem/README.md](filesystem/README.md)
 * [app/README.md](app/README.md)
-* Docs in [`/doc`](doc) folder
+* Docs in [`/doc`](doc) folder (see [ESP-NOW remote](doc/REMOTE.md))

--- a/doc/REMOTE.md
+++ b/doc/REMOTE.md
@@ -1,0 +1,21 @@
+# ESP-NOW Remote Firmware
+
+This optional firmware turns an ESP32 board into a dedicated remote for `rgbw-ctrl`. It sends simple commands to the controller using ESP-NOW and shares much of the same infrastructure (BLE setup, Wi-Fi, OTA updates).
+
+## Capabilities
+
+- Toggle the RGBW controller output via the on-board button
+- Adjust brightness with an optional rotary encoder
+- Pair with a controller over BLE to store its MAC address
+- OTA update support using the same `/update` endpoint
+
+## Building and Flashing
+
+From the `firmware` directory run:
+
+```bash
+pio run -e remote
+pio run -e remote -t upload
+```
+
+See the [main README](../README.md) for general build prerequisites.

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,14 +1,19 @@
 # Firmware
 
-ESP32 source code for the RGBW controller. This PlatformIO project builds the firmware that runs on the device.
+ESP32 source code for the RGBW controller. This PlatformIO project builds two firmware images:
+the main controller (`controller.cpp`) and an optional ESP-NOW remote (`remote.cpp`).
 Requires the PlatformIO CLI (version 6+) or VS Code extension. Building the bundled web UI also requires **Node.js 20+**.
 
 - Edit code in `src/` and headers in `include/`.
 - Configuration lives in `platformio.ini` and `partitions.csv`.
 - Build and upload using [PlatformIO](https://platformio.org/):
   ```bash
-  pio run
-  pio run -t upload
+  # main controller
+  pio run -e controller
+  pio run -e controller -t upload
+  # optional remote
+  pio run -e remote
+  pio run -e remote -t upload
   ```
 - The compiled web UI from `../filesystem` is copied to the `data/` directory before uploading.
 


### PR DESCRIPTION
## Summary
- document optional remote firmware
- mention remote firmware in root README and firmware README

## Testing
- `npm run test` in `app` *(fails: ng not found)*
- `npm test` in `filesystem` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6869258a0994832fab8544197a2149f4